### PR TITLE
Warn explicitly that EOF was encountered while reading the genotype file

### DIFF
--- a/shared/read_data.cpp
+++ b/shared/read_data.cpp
@@ -42,8 +42,12 @@ double*** read_geno(char *in_geno, bool in_bin, bool in_probs, bool *in_logscale
       }
     }
     else{
-      if( gzgets(in_geno_fh, buf, BUFF_LEN) == NULL)
-	error(__FUNCTION__, "cannot read GZip GENO file. Check GENO file and number of sites!");
+      if( gzgets(in_geno_fh, buf, BUFF_LEN) == NULL) {
+        if (gzeof(in_geno_fh))
+          error(__FUNCTION__, "GENO file at premature EOF. Check GENO file and number of sites!");
+        else
+	  error(__FUNCTION__, "cannot read GZip GENO file. Check GENO file and number of sites!");
+      }
       // Remove trailing newline
       chomp(buf);
       // Check if empty


### PR DESCRIPTION
This is a minor change to warn explicitly that a read beyond EOF was attempted when reading a (non-binary) genotype file, instead of issuing a generic error.  Attempting such a read points to the case where the number of individuals specified on the command line is greater than the number of (non-header) lines in the genotype file.  (The other case, where the number of individuals is less, is already handled by the code.)

Admittedly, this change should also be implemented for binary genotype files, but I have not done so here.